### PR TITLE
Fix correctly access `unsafeWindow`

### DIFF
--- a/NamuLink.user.js
+++ b/NamuLink.user.js
@@ -23,7 +23,7 @@
 (() => {
     "use strict";
 
-    unsafeWindow ??= window;
+    const win = typeof unsafeWindow !== "undefined" ? unsafeWindow : window
 
     /// APIs
 
@@ -96,13 +96,13 @@
 
     let PowerLinkLabelCache = [];
     const BitArrayObjs8 = [
-        unsafeWindow.Uint8ClampedArray,
-        unsafeWindow.Int8Array,
-        unsafeWindow.Uint8Array
+        win.Uint8ClampedArray,
+        win.Int8Array,
+        win.Uint8Array
     ];
 
-    unsafeWindow.EventTarget.prototype.addEventListener = new Proxy(
-        unsafeWindow.EventTarget.prototype.addEventListener,
+    win.EventTarget.prototype.addEventListener = new Proxy(
+        win.EventTarget.prototype.addEventListener,
         {
             apply: (target, thisArg, argsList) => {
                 if (/^\/w\//.test(location.pathname) && argsList[0] === "click" && GetBoxRate(thisArg) > 2) {


### PR DESCRIPTION
이전에 특정 유저스크립트 확장기능에서 `unsafeWindow` 가 정의되지 않아 오류가 발생한 사례가 있었습니다.

따라서 [당시의 그 오류를 수정했던 커밋](https://github.com/List-KR/NamuLink/commit/34d9c6f2412bb08eea0f93759e796e61f3113e8b)을 이 PR에서 다시 적용하고자 합니다.

(Strict mode(`"use strict"`)가 걸려있고, `unsafeWindow`가 정의되지 않은 경우, `unsafeWindow ??= window`는 오류를 throw하게 됩니다.)